### PR TITLE
Remote client id

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,3 +563,5 @@ The `41xx` and `51xx` codes are reserved for use by ShareDB DB adapters, and the
 * 5021 - getMilestoneSnapshotAtOrBeforeTime MilestoneDB method unimplemented
 * 5022 - getMilestoneSnapshotAtOrAfterTime MilestoneDB method unimplemented
 * 5023 - getChangelog DB method unimplemented
+* 5024 - _requestIdSeq PubSub method unimplemented
+* 5025 - _resignIdSeq PubSub method unimplemented

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ declare class sharedb<S> extends EventEmitter {
 
   static logger: sharedb.Logger;
 
+  public closing: boolean;
   public db: sharedb.DB;
   public pubsub: sharedb.PubSub;
   public middleware: {
@@ -32,8 +33,9 @@ declare class sharedb<S> extends EventEmitter {
    * @param fields field whitelist for the projection
    */
   addProjection(name: string, collection: string, fields: sharedb.ProjectionFields): void;
-  listen(stream: any, request?: S): void;
+  listen(stream: any, request?: S, remoteId?: string): void;
   close(callback?: (err?: Error) => any): void;
+  drain(timeout: number, callback?: (err?: Error) => any): void;
   /**
    * Registers a server middleware function.
    *
@@ -103,6 +105,8 @@ declare namespace sharedb {
     close(callback?: (err: Error|null) => void): void;
     publish(channels: string[], data: {[k: string]: any}, callback: (err: Error | null) => void): void;
     subscribe(channel: string, callback: (err: Error | null, stream?: Stream) => void): void;
+    requestIdSeq(id: string, callback: (err: Error | null, seq: number) => void): void;
+    resignIdSeq(id: string, seq: number, callback: (err: Error | null) => void): void;
     protected abstract _subscribe(channel: string, callback: (err: Error | null) => void): void;
     protected abstract _unsubscribe(channel: string, callback: (err: Error | null) => void): void;
     protected abstract _publish(channels: string[], data: any, callback: (err: Error | null) => void): void;

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,4 +1,3 @@
-var hat = require('hat');
 var util = require('./util');
 var types = require('./types');
 var ShareDBError = require('./error');
@@ -17,7 +16,10 @@ function Agent(backend, stream) {
   this.backend = backend;
   this.stream = stream;
 
-  this.clientId = hat();
+  // Ids are set by backend on connection
+  this.clientId = null;
+  this.remoteId = null;
+  this.remoteIdSeq = null;
   this.connectTime = Date.now();
 
   // We need to track which documents are subscribed by the client. This is a
@@ -38,14 +40,6 @@ function Agent(backend, stream) {
   // session state in memory. It is in memory only as long as the session is
   // active, and it is passed to each middleware call
   this.custom = {};
-
-  // Initialize the remote client by sending it its agent Id.
-  this.send({
-    a: 'init',
-    protocol: 1,
-    id: this.clientId,
-    type: types.defaultType.uri
-  });
 }
 module.exports = Agent;
 
@@ -66,8 +60,7 @@ Agent.prototype._cleanup = function() {
 
   this.closed = true;
 
-  this.backend.agentsCount--;
-  if (!this.stream.isServer) this.backend.remoteAgentsCount--;
+  this.backend.onAgentCleanup(this);
 
   // Clean up doc subscription streams
   for (var collection in this.subscribedDocs) {
@@ -112,7 +105,7 @@ Agent.prototype._subscribeToStream = function(collection, id, stream) {
     }
     if (data.a === 'p') {
       // Send other clients' presence data
-      if (data.src !== agent.clientId) agent.send(data);
+      if (data.src !== agent.clientId && !agent.backend.closing) agent.send(data);
       return;
     }
     if (agent._isOwnOp(collection, data)) return;
@@ -254,11 +247,21 @@ Agent.prototype._reply = function(request, err, message) {
   });
 };
 
+Agent.prototype._init = function() {
+  // Initialize the remote client by sending it its agent Id.
+  this.send({
+    a: 'init',
+    protocol: 1,
+    id: this.clientId,
+    type: types.defaultType.uri
+  });
+}
+
 // Start processing events from the stream
 Agent.prototype._open = function() {
   if (this.closed) return;
-  this.backend.agentsCount++;
-  if (!this.stream.isServer) this.backend.remoteAgentsCount++;
+
+  this.backend.onAgentOpen(this);
 
   var agent = this;
   this.stream.on('data', function(chunk) {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -13,6 +13,8 @@ var Changelog = require('./changelog');
 var StreamSocket = require('./stream-socket');
 var SubmitRequest = require('./submit-request');
 var types = require('./types');
+var hat = require('hat');
+var logger = require('./logger');
 
 var warnDeprecatedDoc = true;
 var warnDeprecatedAfterSubmit = true;
@@ -40,6 +42,8 @@ function Backend(options) {
   // The number of open agents for monitoring and testing memory leaks
   this.agentsCount = 0;
   this.remoteAgentsCount = 0;
+
+  this.closing = false;
 
   // The below shims are for backwards compatibility. These options will be
   // removed in a future major version
@@ -169,14 +173,88 @@ Backend.prototype.connect = function(connection, req) {
  *
  * (The agent is available through all middleware)
  */
-Backend.prototype.listen = function(stream, req) {
+Backend.prototype.listen = function(stream, req, remoteId) {
+  var backend = this;
   var agent = new Agent(this, stream);
+  if(remoteId != null) {
+    backend.pubsub.requestIdSeq(remoteId, function (err, seq) {
+      if (err) return agent.close(err);
+      agent.clientId = remoteId + '_' + seq;
+      agent.remoteId = remoteId;
+      agent.remoteIdSeq = seq;
+      backend._listen(agent, stream, req);
+    });
+  } else {
+    agent.clientId = hat();
+    backend._listen(agent, stream, req);
+  }
+
+  return agent;
+};
+
+Backend.prototype._listen = function(agent, stream, req) {
+  agent._init();
   this.trigger(this.MIDDLEWARE_ACTIONS.connect, agent, {stream: stream, req: req}, function(err) {
     if (err) return agent.close(err);
     agent._open();
   });
-  return agent;
-};
+}
+
+/**
+ * Called by agents when they open and start processing data
+ */
+Backend.prototype.onAgentOpen = function(agent) {
+  this.agentsCount++;
+  if (!agent.stream.isServer) this.remoteAgentsCount++;
+  this.emit('agent-open', agent);
+}
+
+/**
+ * Called by agents when they are closed and cleaned up
+ */
+Backend.prototype.onAgentCleanup = function(agent) {
+  if (agent.remoteId != null && agent.remoteIdSeq != null) {
+    var backend = this;
+    this.pubsub.resignIdSeq(agent.remoteId, agent.remoteIdSeq, function(err) {
+      if(err) logger.error('resignIdSeq', agent.remoteId, agent.remoteIdSeq, err);
+      backend._onAgentCleanup(agent);
+    });
+  } else {
+    this._onAgentCleanup(agent);
+  }
+}
+
+Backend.prototype._onAgentCleanup = function(agent) {
+  this.agentsCount--;
+  if (!agent.stream.isServer) this.remoteAgentsCount--;
+  this.emit('agent-cleanup', agent);
+}
+
+/**
+ * Wait until all remote agents are cleaned up or timeout
+ */
+Backend.prototype.drain = function(timeout, callback) {
+  var backend = this;
+  var drained = false;
+  var timedOut = false;
+
+  var timer = setTimeout(function() {
+    timedOut = true;
+    wait();
+  }, timeout);
+
+  function wait() {
+    if(!drained && (backend.remoteAgentsCount <= 0 || timedOut)) {
+      drained = true;
+      backend.off('agent-cleanup', wait);
+      clearTimeout(timer);
+      return callback(timedOut ? new Error('Drain timed out') : null);
+    }
+  }
+
+  this.on('agent-cleanup', wait);
+  wait();
+}
 
 Backend.prototype.addProjection = function(name, collection, fields) {
   if (this.projections[name]) {

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -1403,6 +1403,7 @@ Doc.prototype._setPresence = function(src, data, emit) {
   if (data == null) {
     if (this.presence[src] == null) return false;
     delete this.presence[src];
+    delete this.receivedPresence[src];
   } else {
     var isPresenceEqual =
       this.presence[src] === data ||

--- a/lib/pubsub/index.js
+++ b/lib/pubsub/index.js
@@ -54,6 +54,18 @@ PubSub.prototype._publish = function(channels, data, callback) {
   });
 };
 
+PubSub.prototype._requestIdSeq = function(id, callback) {
+  process.nextTick(function() {
+    callback(new ShareDBError(5024, '_requestIdSeq PubSub method unimplemented'));
+  });
+}
+
+PubSub.prototype._resignIdSeq = function(id, seq, callback) {
+  process.nextTick(function() {
+    callback(new ShareDBError(5025, '_resignIdSeq PubSub method unimplemented'));
+  });
+}
+
 PubSub.prototype.subscribe = function(channel, callback) {
   if (!callback) callback = this._defaultCallback;
   if (this.prefix) {
@@ -129,6 +141,16 @@ PubSub.prototype._removeStream = function(channel, stream) {
 
   this._unsubscribe(channel, this._defaultCallback);
 };
+
+PubSub.prototype.requestIdSeq = function(id, callback) {
+  if (!callback) callback = this._defaultCallback;
+  this._requestIdSeq(id, callback);
+}
+
+PubSub.prototype.resignIdSeq = function(id, seq, callback) {
+  if (!callback) callback = this._defaultCallback;
+  this._resignIdSeq(id, seq, callback);
+}
 
 function shallowCopy(object) {
   var out = {};

--- a/lib/pubsub/memory.js
+++ b/lib/pubsub/memory.js
@@ -1,4 +1,5 @@
 var PubSub = require('./index');
+var SeqBitmap = require('../seq-bitmap');
 
 // In-memory ShareDB pub/sub
 //
@@ -11,6 +12,8 @@ var PubSub = require('./index');
 function MemoryPubSub(options) {
   if (!(this instanceof MemoryPubSub)) return new MemoryPubSub(options);
   PubSub.call(this, options);
+
+  this.seqBitmap = new SeqBitmap();
 }
 module.exports = MemoryPubSub;
 
@@ -36,3 +39,18 @@ MemoryPubSub.prototype._publish = function(channels, data, callback) {
     if (callback) callback();
   });
 };
+
+MemoryPubSub.prototype._requestIdSeq = function(id, callback) {
+  var pubsub = this;
+  process.nextTick(function() {
+    callback(null, pubsub.seqBitmap.requestNext(id));
+  });
+}
+
+MemoryPubSub.prototype._resignIdSeq = function(id, seq, callback) {
+  var pubsub = this;
+  process.nextTick(function() {
+    pubsub.seqBitmap.resign(id, seq);
+    callback();
+  });
+}

--- a/lib/seq-bitmap.js
+++ b/lib/seq-bitmap.js
@@ -8,7 +8,7 @@ function SeqBitmap() {
  * Get the lowest available sequence index for the provided id and mark it as in use.
  */
 SeqBitmap.prototype.requestNext = function(id) {
-  if (this.map[id] == null) {
+  if (this.map[id] === undefined) {
     this.map[id] = [0];
   }
 

--- a/lib/seq-bitmap.js
+++ b/lib/seq-bitmap.js
@@ -1,0 +1,60 @@
+module.exports = SeqBitmap;
+
+function SeqBitmap() {
+  this.map = {};
+}
+
+/**
+ * Get the lowest available sequence index for the provided id and mark it as in use.
+ */
+SeqBitmap.prototype.requestNext = function(id) {
+  if (this.map[id] == null) {
+    this.map[id] = [0];
+  }
+
+  var idx = 0;
+  while (idx < this.map[id].length && this.map[id][idx] === -1) {
+    idx++;
+  }
+
+  if (idx === this.map[id].length) {
+    this.map[id].push(0);
+  }
+
+  var pos = 0;
+  var mask = 0x80000000;
+  while ((this.map[id][idx] & mask) !== 0) {
+    mask = mask >>> 1;
+    pos++;
+  }
+
+  this.map[id][idx] = this.map[id][idx] | mask;
+
+  return idx * 32 + pos;
+}
+
+/**
+ * Resign the sequence index for the provided id and mark it as not in use
+ */
+SeqBitmap.prototype.resign = function(id, seq) {
+  if (this.map[id] == null) {
+    return;
+  }
+
+  var idx = Math.floor(seq / 32);
+  if(idx >= this.map[id].length) {
+    return;
+  }
+
+  var pos = seq - (idx * 32);
+  var mask = ~(0x1 << 31 - pos);
+  this.map[id][idx] = this.map[id][idx] & mask;
+
+  while (this.map[id].length > 0 && this.map[id][this.map[id].length - 1] === 0) {
+    this.map[id].pop();
+  }
+
+  if(this.map[id].length === 0) {
+    delete this.map[id];
+  }
+}

--- a/test/seq-bitmap.js
+++ b/test/seq-bitmap.js
@@ -1,0 +1,108 @@
+var expect = require('expect.js');
+var SeqBitmap = require('../lib/seq-bitmap');
+
+describe('SeqBitmap', function () {
+  var sbm;
+
+  beforeEach(function () {
+    sbm = new SeqBitmap();
+  });
+
+  it('should return incrementing sequences', () => {
+    for(var i = 0; i < 1024; i++) {
+      var seq = sbm.requestNext('a');
+      expect(seq).to.equal(i);
+    }
+
+    expect(sbm.map['a']).to.have.length(32);
+  });
+
+  it('should re-use resigned seq', () => {
+    expect(sbm.requestNext('a')).to.equal(0);
+    expect(sbm.requestNext('a')).to.equal(1);
+    sbm.resign('a', 0);
+    expect(sbm.requestNext('a')).to.equal(0);
+    expect(sbm.requestNext('a')).to.equal(2);
+    sbm.resign('a', 0);
+    sbm.resign('a', 1);
+    sbm.resign('a', 2);
+    expect(sbm.requestNext('a')).to.equal(0);
+    expect(sbm.requestNext('a')).to.equal(1);
+    expect(sbm.requestNext('a')).to.equal(2);
+    expect(sbm.requestNext('a')).to.equal(3);
+  });
+
+  it('should re-use resigned seq across ints', () => {
+    for(var i = 0; i < 1024; i++) {
+      var seq = sbm.requestNext('a');
+      expect(seq).to.equal(i);
+    }
+
+    sbm.resign('a', 0);
+    sbm.resign('a', 31);
+    sbm.resign('a', 32);
+    sbm.resign('a', 76);
+    sbm.resign('a', 974);
+    sbm.resign('a', 128);
+
+    expect(sbm.requestNext('a')).to.equal(0);
+    expect(sbm.requestNext('a')).to.equal(31);
+    expect(sbm.requestNext('a')).to.equal(32);
+    expect(sbm.requestNext('a')).to.equal(76);
+    expect(sbm.requestNext('a')).to.equal(128);
+    expect(sbm.requestNext('a')).to.equal(974);
+    expect(sbm.requestNext('a')).to.equal(1024);
+  });
+
+  it('should keep sparse ints and re-use', () => {
+    for(var i = 0; i < 1024; i++) {
+      var seq = sbm.requestNext('a');
+      expect(seq).to.equal(i);
+    }
+
+    for(var i = 32; i < 64; i++) {
+      sbm.resign('a', i);
+    }
+
+    expect(sbm.map['a']).to.have.length(32);
+    expect(sbm.map['a'][1]).to.equal(0);
+
+    for(var i = 0; i < 32; i++) {
+      var seq = sbm.requestNext('a');
+      expect(seq).to.equal(i + 32);
+    }
+
+    expect(sbm.map['a'][1]).to.equal(-1);
+  });
+
+  it('should cleanup unused integers', () => {
+    for(var i = 0; i < 1024; i++) {
+      var seq = sbm.requestNext('a');
+      expect(seq).to.equal(i);
+    }
+
+    expect(sbm.map['a']).to.have.length(32);
+
+    for(var i = 32; i < 1024; i++) {
+      sbm.resign('a', i);
+    }
+
+    expect(sbm.map['a']).to.have.length(1);
+  });
+
+  it('should cleanup unused entries', () => {
+    for(var i = 0; i < 1024; i++) {
+      var seq = sbm.requestNext('a');
+      expect(seq).to.equal(i);
+    }
+
+    expect(sbm.map['a']).to.have.length(32);
+
+    for(var i = 0; i < 1024; i++) {
+      sbm.resign('a', i);
+    }
+
+    expect(sbm.map['a']).to.equal(undefined);
+    expect(Object.keys(sbm.map).length).to.equal(0);
+  });
+});


### PR DESCRIPTION
Allows setting a predictable client id. Each connection with the same remote id will get an incrementing suffix with the lowest available integer starting from 0 `"some-id_0"`, `"some-id_1"`.

N: number of connected remote ids
C: number of connections per remote id

Time on connect: O(C)
Time on disconnect: O(C)
Space requirements: O(N*C/32)